### PR TITLE
(2110): 공유기 설치 -- 예외처리

### DIFF
--- a/boj/choi.2110.py
+++ b/boj/choi.2110.py
@@ -1,0 +1,56 @@
+"""D 이상의 배치가 가능? → last true를 찾는 문제
+```
+T T T T T T F F F F ...
+          ^
+```
+"""
+
+from dataclasses import dataclass
+from typing import Callable, List
+
+MAX_DIST = 1_000_000_000
+
+
+def first_false(lo: int, hi: int, pred: Callable[[int], bool]) -> int:
+    """
+    ```
+    T T T T F F F ...
+            ^
+    ```
+    """
+    while lo != hi:
+        mid = lo + (hi - lo) // 2
+        if pred(mid):
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
+
+
+@dataclass
+class MyPredicate:
+    derivations: List[int]  # 정렬된 집들 사이의 거리를 저장한 배열
+    c: int  # 공유기 개수
+
+    def predicate(self, distance: int) -> bool:
+        """distance 길이의 공유기 배치가 가능한지 여부를 판단"""
+        remain = self.c - 1  # ∵ [0]번 포인트에는 무조건 공유기를 설치할 것이기 때문
+        tmp_dist = 0
+        for delta in self.derivations:
+            tmp_dist += delta
+            if distance <= tmp_dist:
+                # 공유기 설치 가능
+                tmp_dist = 0
+                remain -= 1
+        return remain <= 0
+
+
+n, c = [int(x) for x in input().split()]
+point_ls = sorted([int(input()) for _ in range(n)])
+derivations = [0 for _ in range(len(point_ls) - 1)]
+for i in range(len(point_ls) - 1):
+    derivations[i] = point_ls[i + 1] - point_ls[i]
+
+mypredicate = MyPredicate(derivations, c)
+
+print(first_false(1, max(point_ls) - min(point_ls), mypredicate.predicate) - 1)

--- a/boj/choi.2110.py
+++ b/boj/choi.2110.py
@@ -53,4 +53,4 @@ for i in range(len(point_ls) - 1):
 
 mypredicate = MyPredicate(derivations, c)
 
-print(first_false(1, max(point_ls) - min(point_ls), mypredicate.predicate) - 1)
+print(first_false(1, max(point_ls) - min(point_ls) + 1, mypredicate.predicate) - 1)


### PR DESCRIPTION
이분탐색의 결정조건:

> `D` 이상의 공유기 배치가 가능?

last true를 찾아야 하기 때문에 이분탐색을 `first_false`로 바꿔서 풀었다.

predicate을 클래스 안에 정의하여 내부 상태를 알아서 참조하게 만들었는데, 전역변수를 사용하는 것보다 깔끔하고 좋은 것 같다.

`@dataclass` 어노테이션은 단순히 멤버를 찾아다 `__init__`, `__repr__` 등의 매직메서드를 선언해 주는것에 불과하다는 것을 알았다.